### PR TITLE
Improve performance a lot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ cargo install --path .
 # Usage
 
 ```sh
-sdunpack file.dict [file.syn] < file.idx > file.txt
+sdunpack file.txt file.idx file.dict [file.syn]
 ```
 
 # Convert StarDict to dictd
@@ -16,7 +16,7 @@ This example relies on some of the command line utilities provided by [dictd](ht
 
 ```sh
 dictzip -d file.dict.dz
-sdunpack file.dict file.syn < file.idx > file.txt
+sdunpack file.txt file.idx file.dict file.syn
 short_name=$(grep '^bookname=' file.ifo | cut -d '=' -f 2)
 url=$(grep '^website=' file.ifo | cut -d '=' -f 2)
 dictfmt --utf8 --index-keep-orig --headword-separator '|' -s "$short_name" -u "$url" -t file2 < file.txt

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,75 +1,104 @@
+use std::collections::HashMap;
 use std::env;
 use std::fs::File;
-use std::collections::HashMap;
-use std::io::{self, Read, BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::str;
+
+static SEPARATOR: &str = "_____\n\n";
+
+// https://stardict-4.sourceforge.net/StarDictFileFormat
 
 fn main() {
     let mut args = env::args().skip(1);
-    let path = args.next().expect("Path argument");
+    let output_path = args.next().expect("Output argument");
+    let index_path = args.next().expect("Index argument");
+    let dict_path = args.next().expect("Path argument");
     let syn_path = args.next();
+
+    // Open files here, to fail early if we can’t
+    let mut index_reader = BufReader::new(File::open(&index_path).expect("Open index"));
+    let mut dict_file = File::open(&dict_path).expect("Open dictionary");
+    let mut output_file = File::create(&output_path).expect("Open output");
+
     let mut number = [0; 4];
     let mut synonyms: HashMap<u32, Vec<String>> = HashMap::new();
 
     if let Some(syn_path) = syn_path {
-        let mut syn_reader = BufReader::new(File::open(&syn_path)
-                                                 .expect("Open synonyms"));
+        let mut syn_reader = BufReader::new(File::open(&syn_path).expect("Open synonyms"));
+        let mut word = Vec::with_capacity(100);
         loop {
-            let mut word = Vec::new();
-            let nb = syn_reader.read_until(b'\0', &mut word)
-                               .expect("Read headword");
+            word.clear();
+            let nb = syn_reader
+                .read_until(b'\0', &mut word)
+                .expect("Read headword");
             if nb == 0 {
                 break;
             }
 
+            word.pop(); // remove '\0'
+            let headword = str::from_utf8(&word).expect("Decode headword");
 
-            word.pop();
-
-            let headword = String::from_utf8(word).expect("Decode headword");
             syn_reader.read_exact(&mut number).expect("Read offset");
             let offset = u32::from_be_bytes(number);
 
             if let Some(v) = synonyms.get_mut(&offset) {
-                v.push(headword);
+                v.push(headword.to_string());
             } else {
-                synonyms.insert(offset, vec![headword]);
+                synonyms.insert(offset, vec![headword.to_string()]);
             }
         }
     }
 
-    let mut dict_reader = File::open(&path).expect("Open dictionary");
-    let mut index_reader = BufReader::new(io::stdin()); 
     let mut index_offset = 0;
-
+    let mut write_buffer = String::with_capacity(1_005_000);
+    let mut word = Vec::with_capacity(200);
     loop {
-        let mut word = Vec::new();
-        let nb = index_reader.read_until(b'\0', &mut word)
-                             .expect("Read headword");
+        word.clear();
+        let nb = index_reader
+            .read_until(b'\0', &mut word)
+            .expect("Read headword");
 
         if nb < 2 {
             break;
         }
 
-        word.pop();
+        word.pop(); // remove '\0'
+        let headword = str::from_utf8(&word).expect("Decode headword");
 
-        let mut headwords = vec![String::from_utf8(word).expect("Decode headword")];
         index_reader.read_exact(&mut number).expect("Read offset");
-        let offset = u32::from_be_bytes(number) as u64;
+        let offset = u32::from_be_bytes(number);
         index_reader.read_exact(&mut number).expect("Read size");
         let size = u32::from_be_bytes(number) as usize;
 
-        dict_reader.seek(SeekFrom::Start(offset)).expect("Seek offset");
+        dict_file
+            .seek(SeekFrom::Start(offset as u64))
+            .expect("Seek offset");
         let mut data = vec![0u8; size];
-        dict_reader.read_exact(&mut data).expect("Read data");
-        let data = String::from_utf8(data).expect("Encode data");
+        dict_file.read_exact(&mut data).expect("Read data");
+        let definition = str::from_utf8(&data).expect("Decode definition");
 
-        if let Some(mut v) = synonyms.remove(&index_offset) {
-            headwords.append(&mut v);
+        write_buffer.push_str(SEPARATOR);
+        write_buffer.push_str(headword);
+        if let Some(syns) = synonyms.get_mut(&index_offset) {
+            for syn in syns {
+                write_buffer.push('|');
+                write_buffer.push_str(syn);
+            }
+            // Reduce memory usage and makes it faster for next iteration
+            synonyms.remove(&index_offset);
         }
+        write_buffer.push('\n');
+        write_buffer.push_str(definition);
+        write_buffer.push('\n');
 
-        println!("_____\n");
-        println!("{}", headwords.join("|"));
-        println!("{}", data);
+        // This avoid using too much memory and doesn’t hurt performance
+        if write_buffer.len() >= 1_000_000 {
+            write!(output_file, "{}", write_buffer).expect("Write to output");
+            write_buffer.clear();
+        }
 
         index_offset += 1;
     }
+
+    write!(output_file, "{}", write_buffer).expect("Write to output");
 }


### PR DESCRIPTION
- Smarter use of buffers
- Read and write to file instead of standard input and output

Benchmarks on my computer on https://github.com/BoboTiG/ebook-reader-dict/releases/tag/fr

Original code: ⩾9s
This code: ⩾2s

Every change has been tested before/after with `hyperfine` and I checked that the produced files are exactly the same for several (2) dictionaries.

Ideally, I would like to be able to bypass `dictfmt` in the Plato script and produce directly a DICT.org file but I have trouble finding a good documentation about the format.